### PR TITLE
fix typo in clear url description

### DIFF
--- a/_includes/sections/browser-addons.html
+++ b/_includes/sections/browser-addons.html
@@ -47,7 +47,7 @@
 {% include cardv2.html
   title="ClearURLs"
   image="/assets/img/svg/3rd-party/clearurls.svg"
-  description="<strong>ClearURLs</strong> will automatically remove tracking elements from URLs to help protect your privacy when browse through the Internet."
+  description="<strong>ClearURLs</strong> will automatically remove tracking elements from URLs to help protect your privacy when browsing through the Internet."
   website="https://gitlab.com/KevinRoebert/ClearUrls"
   privacy-policy="https://gitlab.com/KevinRoebert/ClearUrls/-/blob/master/PRIVACY.md"
   forum="https://forum.privacytools.io/t/discussion-clearurls/3353"


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description
This pull request fixes a typo in our description of the clearurl addon.
Resolves: #none <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-1953--privacytools-io.netlify.app/browsers/#addons


