### PR TITLE
Update Cloud Storage

### DIFF
--- a/_includes/sections/cloud-storage.html
+++ b/_includes/sections/cloud-storage.html
@@ -24,26 +24,6 @@
   github="https://github.com/nextcloud"
 %}
 
-{%
-  include cardv2.html
-  title="Keybase KBFS"
-  image="/assets/img/svg/3rd-party/keybase.svg"
-  description='Keybase provides 250GB of E2EE cloud storage for free. Its protocol has also been <a href="https://keybase.io/docs-assets/blog/NCC_Group_Keybase_KB2018_Public_Report_2019-02-27_v1.3.pdf">indepedently audited (PDF)</a>. Keybase allows you to share files with any Keybase user, or social media user through the use of "<a href="https://en.wikipedia.org/wiki/Keybase#Identity_proofs">identity proofs</a>". They currently do not offer additional space above your quota.'
-  labels="color==warning::link==https://github.com/keybase/client/issues/6374::text==Warning::tooltip==This software relies on a closed-source central server.| color==info::link==https://github.com/privacytools/privacytools.io/issues/1894::text==Ownership change::tooltip==Keybase has recently been acquired by Zoom."
-  website="https://book.keybase.io/docs/files"
-  privacy-policy="https://keybase.io/docs/privacypolicy"
-  forum="https://forum.privacytools.io/t/discussion-keybase/1224"
-  tor="http://keybase5wmilwokqirssclfnsqrjdsi7jdir5wy7y7iu3tanwmtp6oid.onion/"
-  github="https://github.com/keybase/client/tree/master/go/kbfs"
-  windows="https://keybase.io/docs/the_app/install_windows"
-  mac="https://keybase.io/docs/the_app/install_macos"
-  linux="https://keybase.io/docs/the_app/install_linux"
-  freebsd="https://www.freshports.org/security/keybase/"
-  googleplay="https://play.google.com/store/apps/details?id=io.keybase.ossifrage"
-  ios="https://apps.apple.com/app/keybase-crypto-for-everyone/id1044461770"
-%}
-
-
 <h3>Worth Mentioning</h3>
 
 <ul>


### PR DESCRIPTION
#### Description

From #1951 :

> This pull request will remove Keybase from the privacytools recommendations because of the sell out to zoom and the willingness of zoom the work with Law enforcement by knowingly not providing secure end to end encryption to free users, thereby putting millions of peoples data at risk. see details in #1894 .

Resolves: #1894

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: https://deploy-preview-1955--privacytools-io.netlify.app/providers/cloud-storage/