### PR TITLE
Remove erroneous NextCloud link from Signal badge

### DIFF
--- a/_includes/sections/instant-messenger.html
+++ b/_includes/sections/instant-messenger.html
@@ -24,7 +24,7 @@
   title="Signal"
   image="/assets/img/svg/3rd-party/signal.svg"
   description='Signal is a mobile app developed by Signal Messenger LLC. The app provides instant messaging, as well as voice and video calling. All communications are E2EE unless you choose to send as SMS. Its protocol has also been <a href="https://eprint.iacr.org/2016/1013.pdf">indepedently audited (PDF)</a>'
-  labels="color==warning::link==https://github.com/nextcloud/end_to_end_encryption/issues/111::text==Requires phone number::tooltip==Signal requires your phone number as an personal identifier which means anyone you communicate with will see it.|text==VoIP"
+  labels="color==warning::text==Requires phone number::tooltip==Signal requires your phone number as an personal identifier which means anyone you communicate with will see it.|text==VoIP"
   website="https://signal.org/"
   privacy-policy="https://signal.org/legal/"
   forum="https://forum.privacytools.io/t/discussion-signal/664"


### PR DESCRIPTION
Closes: https://github.com/privacytools/privacytools.io/issues/1978

https://deploy-preview-1979--privacytools-io.netlify.app/software/real-time-communication/#centralized