### PR TITLE
Updated Onion Browser iOS limitations link

### DIFF
--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -112,7 +112,7 @@
 {% include cardv2.html
   title="Onion Browser"
   image="/assets/img/svg/3rd-party/onion_browser.svg"
-  description='Onion Browser is an open-source browser that lets you browse the web anonymously over the Tor network on iOS devices and is endorsed by the Tor Project. Warning: there are certain anonymity-related <a href="https://onionbrowser.com/#security-advisories">issues</a> with Onion Browser due to iOS limitations.'
+  description='Onion Browser is an open-source browser that lets you browse the web anonymously over the Tor network on iOS devices and is endorsed by the Tor Project. Warning: there are certain anonymity-related <a href="https://onionbrowser.com/about">issues</a> with Onion Browser due to iOS limitations.'
   website="https://onionbrowser.com/"
   privacy-policy="https://onionbrowser.com/privacy-policy"
   forum="https://forum.privacytools.io/t/discussion-onion-browser-browsers/1523"


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

The original link for the Onion Browser on the iOS Browser Recommendations (located at: https://www.privacytools.io/browsers/#browser-ios) (original link: https://onionbrowser.com/#security-advisories) defaulted to the homepage with no information about iOS's limitations. Replaced it with the about page which has information on the limitations.

## Description

Resolves: https://github.com/privacytools/privacytools.io/issues/1999 <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software