### PR TITLE
Replace Alt-Svc with Onion-Location header

### DIFF
--- a/nginx/010-headers.conf
+++ b/nginx/010-headers.conf
@@ -4,7 +4,7 @@ add_header X-Content-Type-Options nosniff always;
 add_header Content-Security-Policy "default-src 'none'; script-src 'self' https://stats.privacytools.io; style-src 'self'; img-src 'self' data: https://*.privacytools.io; object-src 'none'; frame-src https://stats.privacytools.io; font-src 'self'; base-uri 'none'; form-action 'self' https://search.privacytools.io; frame-ancestors 'none'; manifest-src 'self';" always;
 add_header 'Access-Control-Allow-Origin' '*';
 add_header Strict-Transport-Security "max-age=31557600; includeSubDomains; preload";
-add_header Alt-Svc 'h2="privacy2zbidut4m4jyj3ksdqidzkw3uoip2vhvhbvwxbqux5xy5obyd.onion:443"; ma=86400; persist=1';
+add_header Onion-Location http://privacy2zbidut4m4jyj3ksdqidzkw3uoip2vhvhbvwxbqux5xy5obyd.onion$request_uri always;
 add_header Expect-CT 'max-age=86400, enforce';
 add_header Referrer-Policy "strict-origin";
 add_header Feature-Policy "geolocation none;midi none;notifications none;push none;sync-xhr none;microphone none;camera none;magnetometer none;gyroscope none;speaker self;vibrate none;fullscreen self;payment none;";


### PR DESCRIPTION
Onion-Location is a preferred way by Tor Project to indicate an
available onion service. It allows users to make Tor Browser always use
onion version or to keep using clearnet in a seamless way.

https://community.torproject.org/onion-services/advanced/onion-location/

---

Example sites:
* https://torproject.org
* https://dawidpotocki.com