### PR TITLE
Remove datacenter and announce Singapore server

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -87,6 +87,10 @@ We also log how many times this or that tracker has been blocked. We need this i
             <span class="flag-icon flag-icon-jp"></span>
             Japan
           </span>
+          <span class="no-text-wrap">
+            <span class="flag-icon flag-icon-sg"></span>
+            Singapore
+          </span>
         </td>
         <td>
           <div
@@ -116,12 +120,9 @@ We also log how many times this or that tracker has been blocked. We need this i
           </span>
           <span class="no-text-wrap">
             malicious domains
-            {% include badge.html
-            link="https://github.com/ookangzheng/blahdns#default-blocked-wildcard-domain"
-            color="warning"
-            icon="fas fa-exclamation-triangle"
-            tooltip="And some wildcard and IDN domains."
-            %}
+          </span>
+          <span class="no-text-wrap">
+            Based on server choice only for DoH
           </span>
         </td>
         <td>
@@ -134,9 +135,6 @@ We also log how many times this or that tracker has been blocked. We need this i
         <td>
           <span class="no-text-wrap">
             <a href="https://www.choopa.com/">Choopa, LLC</a>,
-          </span>
-          <span class="no-text-wrap">
-            <a href="https://www.datacenterlight.ch/">Data Center Light</a>,
           </span>
           <span class="no-text-wrap">
             <a href="https://www.hetzner.com/">Hetzner Online GmbH</a>


### PR DESCRIPTION
## Description

Resolves: 
1. Blahdns do not filter IDN already.
2. Added Singapore server.
3. Blahdns do have uncensored DNS only for DoH, e.x: https://doh1.blahdns.com/uncensor 

#### Check List 

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x]  I have read and understood [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-2025--privacytools-io.netlify.app/providers/dns/

* Code repository of the project (if applicable):
