### PR TITLE
Change Icon for Firefox Mobile Source Code

### DIFF
--- a/_includes/sections/browser-recommendation.html
+++ b/_includes/sections/browser-recommendation.html
@@ -47,7 +47,7 @@
   website="https://www.mozilla.org/en-US/firefox/mobile/"
   privacy-policy="https://www.mozilla.org/en-US/privacy/firefox/"
   forum="https://forum.privacytools.io/t/discussion-firefox/279"
-  source="https://github.com/mozilla-mobile"
+  github="https://github.com/mozilla-mobile"
   fdroid="https://f-droid.org/en/packages/org.mozilla.fennec_fdroid/"
   googleplay="https://play.google.com/store/apps/details?id=org.mozilla.firefox"
   android="https://www.mozilla.org/firefox/all/#product-android-release"
@@ -104,7 +104,7 @@
   website="https://www.mozilla.org/en-US/firefox/mobile/"
   privacy-policy="https://www.mozilla.org/en-US/privacy/firefox/"
   forum="https://forum.privacytools.io/t/discussion-firefox/279"
-  source="https://github.com/mozilla-mobile/firefox-ios"
+  github="https://github.com/mozilla-mobile/firefox-ios"
   ios="https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926"
 %}
 


### PR DESCRIPTION
- Had generic source logo before even though it link to a GitHub page

<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #2024  <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

Previously, the links to the source code for both [Firefox for Android](https://www.privacytools.io/browsers/#browser-android) and [Firefox for iOS](https://www.privacytools.io/browsers/#browser-ios) had a generic "source" icon even though it linked to a GitHub page. 

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: https://5f45ae359ced2e0008aeae76--privacytools-io.netlify.app/browsers/<!-- link or Non Applicable? Edit this in afterwards -->
