### PR TITLE
Replaced invidio.us link with an alternative Individuous instance

### DIFF
--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -271,7 +271,7 @@ breadcrumb: "VPN"
     <div class="row">
       <div class="col-lg-6 col-12">
       <h3>Related Videos</h3>
-        <a href="https://invidio.us/watch?v=WVDQEoe6ZWY" target="_blank">
+        <a href="https://invidiou.site/watch?v=WVDQEoe6ZWY" target="_blank">
           <img
             src="/assets/img/png/layout/this-video-is-sponsored-by-vpn.png"
             class="img-fluid float-left mr-3"


### PR DESCRIPTION
## Description

- This link concerns the video "This Video Is Sponsored By ███ VPN" by Tom Scott, with the Video ID "WVDQEoe6ZWY".
- The [Indivious](https://github.com/iv-org/invidious) instance hosted under the domain "invidio.us" shut down on September 1st, 2020

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [ ] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

(I am not particularly sure if 'similar addition' falls under this category. All I did was replace a broken link, which doesn't amount to adding a new service on the list.)

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page:

Not applicable.

* Code repository of the project (if applicable):

https://github.com/iv-org/invidious