### PR TITLE
Social news aggregators: Fix license for Tildes

### DIFF
--- a/_includes/sections/social-news-aggregator.html
+++ b/_includes/sections/social-news-aggregator.html
@@ -20,7 +20,7 @@ linux="https://getaether.net/download/"
 {% include cardv2.html
 title="Tildes"
 image="/assets/img/svg/3rd-party/tildes.svg"
-description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">GPL 3.0</a>.'
+description='Tildes is a web-based self-hostable online bulletin board. It is licensed under <a href="https://gitlab.com/tildes/tildes/blob/master/LICENSE">AGPLv3</a>.'
 website="https://tildes.net"
 privacy-policy="https://docs.tildes.net/policies/privacy-policy"
 forum="https://forum.privacytools.io/t/discussion-tildes/1257"


### PR DESCRIPTION
Thanks for including Tildes on the site! This is just a tiny fix, since the license info is currently wrong, and the distinction between AGPLv3 and GPL 3.0 is important for a web-based service.