### PR TITLE
Change Android DNS Client Anchor Link to go to Correct Section

### DIFF
--- a/_includes/sections/android-addons.html
+++ b/_includes/sections/android-addons.html
@@ -28,6 +28,6 @@
 
 <ul>
   <li>
-    <a href="/providers/dns#clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.
+    <a href="/providers/dns#dns-android-clients">Our DNS client recommendations</a>, which have information on enabling encrypted DNS on Android.
   </li>
 </ul>


### PR DESCRIPTION
Before it was simply “#clients” which is no longer a correct section on the DNS providers page

<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #2073 <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: https://deploy-preview-2074--privacytools-io.netlify.app/operating-systems/#aaddons<!-- link or Non Applicable? Edit this in afterwards -->
