### PR TITLE
Update Anonymized DNSCrypt relays link to v3

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -648,5 +648,5 @@ We also log how many times this or that tracker has been blocked. We need this i
 
 <h4>Anonymized DNSCrypt</h4>
 <p>
-  A <a href="https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Anonymized-DNS">lightweight protocol</a> that hides the client IP address by using pre-configured relays to forward encrypted DNS data. This is a relatively new protocol created in 2019 currently only supported by <a href="#dns-desktop-clients">dnscrypt-proxy</a> and a limited number of <a href="https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v2/relays.md">relays</a>.
+  A <a href="https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Anonymized-DNS">lightweight protocol</a> that hides the client IP address by using pre-configured relays to forward encrypted DNS data. This is a relatively new protocol created in 2019 currently only supported by <a href="#dns-desktop-clients">dnscrypt-proxy</a> and a limited number of <a href="https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/relays.md">relays</a>.
 </p>


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #none <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

This PR updates the link for the Anonymized DNSCrypt relays from the [legacy v2 version](https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v2/relays.md) to the [current v3 version](https://github.com/DNSCrypt/dnscrypt-resolvers/blob/master/v3/relays.md), which is now used on the [Anonymized DNSCrypt wiki page](https://github.com/DNSCrypt/dnscrypt-proxy/wiki/Anonymized-DNS).

I wasn't sure if I should open an Issue for such a minor fix, as it is not a new software suggestion, but if that is preferred, please let me know.


#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-2076--privacytools-io.netlify.app/providers/dns/

* Code repository of the project (if applicable):
