### PR TITLE
Fix search bar not passing searches to Searx

### DIFF
--- a/_includes/sections/header.html
+++ b/_includes/sections/header.html
@@ -10,7 +10,7 @@
   <p class="lead">You are being watched. Private and state-sponsored organizations are monitoring and recording your online activities. {{ site.name }} provides services, tools and knowledge to protect your privacy against global mass surveillance.</p>
 </div>
 
-<form method="POST" action="https://search.privacytools.io/" id="search_form" role="search">
+<form method="POST" action="https://search.privacytools.io/searx/" id="search_form" role="search">
 <div class="input-group col-12 col-md-8 offset-md-2">
 <input type="search" name="q" class="form-control input-lg" id="q" placeholder="Try {{ site.name }} Search, a Privacy-Respecting Search Engine" autocomplete="off" value="">
 <span class="input-group-btn">


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

The URL to pass searches to was https://search.privacytools.io/searx, instead of https://search.privacytools.io. So I changed the URL of the search bar form.

Resolves: #2085  <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->
https://deploy-preview-2086--privacytools-io.netlify.app/

* Code repository of the project (if applicable):
