### PR TITLE
Fix broken Bootstrap license link in LibreJS page

### DIFF
--- a/pages/about/librejs.html
+++ b/pages/about/librejs.html
@@ -17,7 +17,7 @@ permalink: /about/javascript/
   </tr>
   <tr>
     <td><a href="/assets/js/bootstrap.min.js">bootstrap.min.js</a></td>
-    <td><a href="https://github.com/twbs/bootstrap/raw/master/LICENSE">Expat</a></td>
+    <td><a href="https://github.com/twbs/bootstrap/raw/main/LICENSE">Expat</a></td>
   </tr>
   <tr>
     <td><a href="/assets/js/jquery-3.3.1.min.js">jquery-3.3.1.min.js</a></td>


### PR DESCRIPTION
## Description

Resolves: None.  This seems like such a minor and straightforward fix, that I thought it will be more helpful to you to just have a pull request directly, for you to sign off on with a single click.

But if this doesn't work for you, I can always go create an issue instead.

#### Check List

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: 

* Code repository of the project (if applicable):
