### PR TITLE
Remove ThatOnePrivacySite

### DIFF
--- a/pages/providers/vpn.html
+++ b/pages/providers/vpn.html
@@ -221,7 +221,6 @@ breadcrumb: "VPN"
         <h3>Related VPN information</h3>
 
         <ul>
-          <li><a href="https://thatoneprivacysite.net/vpn-comparison-chart/">Spreadsheet with unbiased, independently verifiable data on over 100 VPN services.</a></li>
           <li><a href="https://blog.privacytools.io/the-trouble-with-vpn-and-privacy-reviews/">The Trouble with VPN and Privacy Review Sites</a></li>
           <li><a href="https://vikingvpn.com/blogs/off-topic/beware-of-vpn-marketing-and-affiliate-programs">Beware of False Reviews - VPN Marketing and Affiliate Programs</a></li>
           <li><a href="https://torrentfreak.com/proxy-sh-vpn-provider-monitored-traffic-to-catch-hacker-130930/">Proxy.sh VPN Provider Sniffed Server Traffic to Catch Hacker</a></li>


### PR DESCRIPTION
<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* https://deploy-preview-2114--privacytools-io.netlify.app/providers/vpn/

So it appears that thatoneprivacysite.net has been sold to another company with just a fairly generic blog. Likely they offered him a lucrative deal for the domain because of the click through rate. These media companies always harass us and ask us to sell our domain to them.

They then just direct it to some fairly generic blog with superficial "tests" and tonnes of affiliate links. The result is low-quality noise that prevents anyone from finding meaningful information. The owners would likely operate many of these websites, which purely exist to generate money for the owners. **The tests are purposely very surface level**, as this requires no work to maintain.

I really think the information provided by thatoneprivacysite.net was not really up to date to begin with, and also there was a lot of absolutely pointless information as well which just made the website appear as if it was being useful.

[Some more of my further personal opinions](https://old.reddit.com/r/privacytoolsIO/comments/jn1l87/that_one_privacy_site_merges_with_safetydetectives/gb2m7t0/).