### PR TITLE
Fix typo

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -571,7 +571,7 @@ We also log how many times this or that tracker has been blocked. We need this i
   include cardv2.html
   title="Firefox's built-in DNS-over-HTTPS resolver"
   image="/assets/img/svg/3rd-party/firefox_browser.svg"
-  description='Firefox comes with built-in DNS-over-HTTPS support for <a href="https://blog.mozilla.org/blog/2020/02/25/firefox-continues-push-to-bring-dns-over-https-by-default-for-us-users/">NextDNS and Cloudflare</a> but users can manually any other DoH resolver.'
+  description='Firefox comes with built-in DNS-over-HTTPS support for <a href="https://blog.mozilla.org/blog/2020/02/25/firefox-continues-push-to-bring-dns-over-https-by-default-for-us-users/">NextDNS and Cloudflare</a> but users can manually use any other DoH resolver.'
   labels="color==warning::icon==fas fa-exclamation-triangle::link==https://developers.cloudflare.com/1.1.1.1/privacy/firefox::text==Warning::tooltip==Cloudflare logs a limited amount of data about the DNS requests that are sent to their custom resolver for Firefox."
   website="https://support.mozilla.org/en-US/kb/firefox-dns-over-https"
   privacy-policy="https://wiki.mozilla.org/Security/DOH-resolver-policy"


### PR DESCRIPTION
Firefox Section

Changed "but users can manually any other DoH resolver." to "but users can manually use any other DoH resolver."

<!-- PLEASE READ OUR CODE OF CONDUCT (https://wiki.privacytools.io/view/PrivacyTools:Code_of_Conduct) AND CONTRIBUTING GUIDELINES (https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md) BEFORE SUBMITTING -->

## Description

Resolves: #none <!-- A link to the (discussion) issue resolved by this pull request. There must be a discussion issue here at GitHub, before a pull request of software/service suggestion can be considered for merging. -->

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->

* Code repository of the project (if applicable):
