### PR TITLE
Change Riot Name and Link to Element

### DIFF
--- a/pages/about/about.html
+++ b/pages/about/about.html
@@ -161,7 +161,7 @@ emeritus=true
     <p><a href="https://github.com/privacytools/privacytools.io/issues"><i class="fab fa-github fa-lg fa-fw"></i> Open an issue on GitHub</a></p>
     <p><a href="https://www.reddit.com/r/privacytoolsIO/"><i class="fab fa-reddit fa-lg fa-fw"></i> Suggest something new on our subreddit</a></p>
     <p>For complete transparency, software and providers will only be considered for this website after discussions take place on our GitHub issue tracker. We of course don't make any changes in secret.</p>
-    <p>Join our Matrix room at <code>#general:privacytools.io</code> to chat with us and other members about this site and privacy in general! If you need a Matrix account, you can sign up with our own homeserver (<code>https://chat.privacytools.io</code>) using <a href="https://riot.privacytools.io">Riot</a>.</p>
+    <p>Join our Matrix room at <code>#general:privacytools.io</code> to chat with us and other members about this site and privacy in general! If you need a Matrix account, you can sign up with our own homeserver (<code>https://chat.privacytools.io</code>) using <a href="https://element.privacytools.io">Element</a>.</p>
     <p>You can also email the team at <a itemprop="email" href="mailto:support@privacytools.io">support@privacytools.io</a> and find us on <a itemprop="sameAs" href="https://twitter.com/privacytoolsIO">Twitter</a> and <a itemprop="sameAs" href="https://social.privacytools.io/@privacytools">Mastodon</a>.</p>
     <link itemprop="sameAs" href="https://blog.privacytools.io">
     <link itemprop="sameAs" href="https://www.youtube.com/channel/UCen3taxHtzByXV8Da73B1Vg">


### PR DESCRIPTION

## Description

Change the mention of "Riot" to "Element" and update the privacytools.io URL accordingly.
Resolves: #2150 

#### Check List

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software
