### PR TITLE
Remove warning from Cryptomator

### DIFF
--- a/_includes/sections/cloud-storage.html
+++ b/_includes/sections/cloud-storage.html
@@ -26,6 +26,6 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration. {% include badge.html color="warning" tooltip="Cryptomator's mobile apps are not open-source." link="https://github.com/cryptomator/cryptomator-android/issues/1#issuecomment-257979375" icon="fas fa-exclamation-triangle" %}</li>
+  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
   <li><a href="https://cryptpad.fr">CryptPad</a> - Free and end-to-end encrypted real time collaboration sharing folders, media, and documents.</li>
 </ul>

--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -55,16 +55,7 @@
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li>
-    <a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.
-    {% include badge.html
-      color="warning"
-      text="Closed source"
-      icon="fas fa-exclamation-triangle"
-      link="https://github.com/cryptomator/cryptomator-android/issues/1#issuecomment-257979375"
-      tooltip="Cryptomator's mobile apps are not open-source."
-    %}
-  </li>
+  <li><a href="https://cryptomator.org/">Cryptomator</a> - Free client-side AES encryption for your cloud files. Open source software: No backdoors, no registration.</li>
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
   <li><a href="https://www.dyne.org/software/tomb/">Tomb</a> - A simple zsh script for making LUKS containers on the commandline.</li>
   <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</li>


### PR DESCRIPTION
## Description

Resolves: #2174

As noted in #2174 currently Cryptomator has an warning for their mobile apps not being open-sourced. Also as stated in #2174 a [blog from Cryptomator](https://cryptomator.org/blog/2020/12/23/android-open-source/) that they've [open-sourced their Android app](https://github.com/cryptomator/android). I've [build](https://bin.privacytools.io/?0c7fce2de934ff90#E0SLKujjWtCHvUjn2VvWHzNmAzVO3En9MjHdW+QfwVo=) the app myself to make sure it is all of their code and not `partially`, after installing it and seeing the compiled source code everything was their with no limitations.
Thereby they are [planning](https://github.com/cryptomator/android/issues/1#issuecomment-752992114) to submit the android app to F-Droid.

After confirming it's fully open-source with no limitations the warning can be removed from Cryptomator.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-2177--privacytools-io.netlify.app/