### PR TITLE
Remove trial notice IVPN

### DIFF
--- a/_includes/sections/vpn.html
+++ b/_includes/sections/vpn.html
@@ -86,7 +86,7 @@
       {% include badge.html color="info" text="Standard USD $60/y" %}
       {% include badge.html color="secondary" text="Pro USD $100/y" %}
     </h2>
-    <p><strong><a href="https://www.ivpn.net">IVPN.net</a></strong> is another premium VPN provider, and they have been in operation since <strong>2009</strong>. IVPN is based in <span class="flag-icon flag-icon-gi"></span> Gibraltar and offers a 3 day free trial.</p>
+    <p><strong><a href="https://www.ivpn.net">IVPN.net</a></strong> is another premium VPN provider, and they have been in operation since <strong>2009</strong>. IVPN is based in <span class="flag-icon flag-icon-gi"></span> Gibraltar.</p>
     <h5>{% include badge.html color="success" text="32 Countries" %}</h5>
     <p>IVPN has <a href="https://www.ivpn.net/server-locations">servers in 32 countries</a> at the time of writing this page. Picking a VPN provider with a server nearest to you will reduce latency of the network traffic you send. This is because of a shorter route (less hops) to the destination.</p>
     <p>We also think it's better for the security of the VPN provider's private keys if they use <a href="https://en.wikipedia.org/wiki/Dedicated_hosting_service">dedicated servers</a>, instead of cheaper shared solutions (with other customers) such as <a href="https://en.wikipedia.org/wiki/Virtual_private_server">virtual private servers</a>.</p>


### PR DESCRIPTION
## Description

Resolves: #2159

As stated in #2159 it seems to be not longer the case that IVPN has a 3 day trial. After a quick wayback machine trip I've found that it had been removed between [October 24th, 2020](https://web.archive.org/web/20201024085618/https://www.ivpn.net/pricing) and [November 26th, 2020](https://web.archive.org/web/20201126002358if_/https://www.ivpn.net/pricing). Whereby at merging #1174 August 17th, 2019 was still true. However now they've removed the trial and [acknowledge](https://www.ivpn.net/knowledgebase/billing/does-ivpn-offer-a-free-trial/) their is no such thing *anymore*. The notice on privacytools.io can be removed as well.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-2178--privacytools-io.netlify.app/