### PR TITLE
Add warning to Invidious

### DIFF
--- a/_includes/sections/video-frontends.html
+++ b/_includes/sections/video-frontends.html
@@ -8,7 +8,8 @@
   title="Invidious"
   image="/assets/img/svg/3rd-party/invidious.svg"
   description='Invidious is an alternative front-end to YouTube. It is free software, with no advertising or Javascript dependency to play videos, with lots of other features that allow you to have a complete YouTube experience, sans Google.'
+  labels="color==warning::icon==fas fa-exclamation-triangle::link==https://github.com/iv-org/documentation/blob/master/Always-use-%22local%22-to-proxy-video-through-the-server-without-creating-an-account.md::text==Warning::tooltip==By default, Invidious will not proxy videos through the instance's proxy."
   website="https://invidio.us"
-  github="https://github.com/omarroth/invidious"
+  github="https://github.com/iv-org/invidious"
   web="https://instances.invidio.us"
 %}


### PR DESCRIPTION
## Description

Resolves: #2144

As described in #2144 the current box is misleading, which I agree with. To clarify why I agree with this:
- As a new user(private window) and open a video you can see it will by default request the video from an google server `googlevideo.com` as seen in the [source code](https://github.com/iv-org/invidious/blob/168376b04671c6e362468267a3b07dd332b40702/src/invidious.cr#L211) where they add the CSP headers when the user has not enabled `local`.
- As seen in the [source code](https://github.com/iv-org/invidious/blob/168376b04671c6e362468267a3b07dd332b40702/src/invidious/helpers/helpers.cr#L38) the default preference for `local` which is the preference to see if the user wants proxied video, is false and by default not proxied if not otherwise changed in the preference *if the instance allows this, some have disabled this to be enabled*.
- As seen in the [source code](https://github.com/iv-org/invidious/blob/168376b04671c6e362468267a3b07dd332b40702/src/invidious.cr#L3479) it will look if the host parameter is in the request and use the custom host if the parameter is found. The call to this webpoint is handled in videos.cr that added the host parameter when user prefers(local preference) it.

I've now added an warning however, I think the whole `proxy` aspect to this can be removed as invidious [main goal](https://github.com/iv-org/invidious#invidious-is-an-alternative-front-end-to-youtube) is provide an front-end and not serve as proxy. I think it's good to make people aware of this as I've heard great things over invidious even to degoogle, however knowing that it's not by default proxied and some instances don't allow this is not common knowledge.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: https://deploy-preview-2182--privacytools-io.netlify.app/

