### PR TITLE
Arch Linux: Ensure correct link to reproducible builds

### DIFF
--- a/_includes/sections/operating-systems.html
+++ b/_includes/sections/operating-systems.html
@@ -45,7 +45,7 @@
   image="/assets/img/svg/3rd-party/archlinux.svg"
   description='A simple, lightweight Linux distribution. It is composed predominantly of free and open-source software, and supports community involvement.'
   badges="info:Linux"
-  labels="color==success::link==https://tests.reproducible-builds.org/archlinux/archlinux.html::text==Reproducible builds"
+  labels="color==success::link==https://reproducible.archlinux.org::text==Reproducible builds"
   website="https://www.archlinux.org/"
   privacy-policy="https://wiki.archlinux.org/index.php/ArchWiki:Privacy_policy"
   gitlab="https://gitlab.archlinux.org"


### PR DESCRIPTION
The CI system is a fuzzer for finding upstream and doesn't necessarily reflect the progress made in Arch. The CI are just checking out some files and builds them twice.

The link moves this to our current rebuilder setup which reproduces distributed packages.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->

* Code repository of the project (if applicable):
