### PR TITLE
DNS: mark Quad9 as Switzerland based

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -415,8 +415,8 @@ We also log how many times this or that tracker has been blocked. We need this i
         </td>
         <td>Anycast (based in
           <span class="no-text-wrap">
-            <span class="flag-icon flag-icon-us"></span>
-            US)
+            <span class="flag-icon flag-icon-ch"></span>
+            Switzerland)
           </span>
         </td>
         <td>


### PR DESCRIPTION
## Description

Resolves: #2212

https://quad9.net/news/blog/quad9-public-domain-name-service-moves-to-switzerland-for-maximum-internet-privacy-protection/


#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [ ] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: 

* Code repository of the project (if applicable): N/A