### PR TITLE
LibreDNS doesn't support DNSSEC

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -264,7 +264,7 @@ We also log how many times this or that tracker has been blocked. We need this i
         </td>
         <td>No</td>
         <td>DoH, DoT</td>
-        <td>Yes</td>
+        <td>No</td>
         <td>Yes</td>
         <td>
           <span class="no-text-wrap">


### PR DESCRIPTION
## Description

Same as #2146.

I asked on [#libreops:matrix.org](https://riot.im/app/#/room/#libreops:matrix.org) if DNSSEC is supported by the LibreDNS service, the answer is:
> [not yet , on our todo list](https://matrix.to/#/!ixcbtfIBdcPeyDEEzR:matrix.org/$161427370750989iDLZN:matrix.org?via=chat.weho.st&via=matrix.org&via=privacytools.io)

Tested with the following commands:

    $ kdig @116.202.176.26 +tls-host=dot.libredns.gr +dnssec sigfail.verteiltesysteme.net
    ;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
    ;; ->>HEADER<<- opcode: QUERY; status: NOERROR; id: 8416
    ;; Flags: qr rd ra; QUERY: 1; ANSWER: 2; AUTHORITY: 0; ADDITIONAL: 1

    ;; EDNS PSEUDOSECTION:
    ;; Version: 0; flags: do; UDP size: 512 B; ext-rcode: NOERROR

    ;; QUESTION SECTION:
    ;; sigfail.verteiltesysteme.net.		IN	A

    ;; ANSWER SECTION:
    sigfail.verteiltesysteme.net.	42	IN	A	134.91.78.139
    sigfail.verteiltesysteme.net.	42	IN	RRSIG	A 5 3 60 20210502030010 20210131030010 30665 verteiltesysteme.net. //This+RRSIG+is+deliberately+broken///For+more+information+please+go+to/http+//www+verteiltesysteme+net///////////////////////////////////////////////////////////////////8=

The status is `NOERROR` and the `AD` flags is missing but the expected status is `SERVAIL`.

This unexpected behavior can be tested with another domain:
```
$ kdig @116.202.176.26 +tls-host=dot.libredns.gr +dnssec www.dnssec-failed.org
;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: NOERROR; id: 62932
;; Flags: qr rd ra; QUERY: 1; ANSWER: 3; AUTHORITY: 0; ADDITIONAL: 1

;; EDNS PSEUDOSECTION:
;; Version: 0; flags: do; UDP size: 512 B; ext-rcode: NOERROR

;; QUESTION SECTION:
;; www.dnssec-failed.org.		IN	A

;; ANSWER SECTION:
www.dnssec-failed.org.	4205	IN	A	68.87.109.242
www.dnssec-failed.org.	4205	IN	A	69.252.193.191
www.dnssec-failed.org.	4205	IN	RRSIG	A 5 3 7200 20210314145058 20210225144558 44973 dnssec-failed.org. ugoAA9teSApCHc8De+5hfxrY/BjD9LSE/fguwdMu0zcvtSF6oIS0iLIY1J94nDecv+YA8YAKC2AcRJhpEIjtaFnTKVrKvTEgr1IMjjujxk7GIGolMht+byvWzPlOf/hGZqlwykNkFRm9syu8OB5oshh/keZC0TflGNA+rUNlET8=
```

Output of the same command using providers with DNSSEC enabled:
```
$ kdig @9.9.9.9 +tls-host=dns.quad9.net sigfail.verteiltesysteme.net
;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(ECDSA-SECP256R1-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: SERVFAIL; id: 18459
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 0; ADDITIONAL: 1

;; QUESTION SECTION:
;; sigfail.verteiltesysteme.net.		IN	A
```
```
 kdig @45.90.57.121 +tls-host=dot-ch.blahdns.com sigfail.verteiltesysteme.net
;; TLS session (TLS1.3)-(ECDHE-SECP256R1)-(RSA-PSS-RSAE-SHA256)-(AES-256-GCM)
;; ->>HEADER<<- opcode: QUERY; status: SERVFAIL; id: 59870
;; Flags: qr rd ra; QUERY: 1; ANSWER: 0; AUTHORITY: 0; ADDITIONAL: 1

;; QUESTION SECTION:
;; sigfail.verteiltesysteme.net.		IN	A
```

#### Check List <!-- Please add an x in each box below, like so: [x] -->
* Netlify preview for the mainly edited page: <!-- link or Non Applicable? Edit this in afterwards -->