### PR TITLE
Correct Broken URL for Akasha

### DIFF
--- a/_includes/sections/social-news-aggregator.html
+++ b/_includes/sections/social-news-aggregator.html
@@ -42,7 +42,7 @@ web="https://raddle.me"
 <h3>Worth Mentioning</h3>
 
 <ul>
-  <li><a href="https://beta.akasha.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
+  <li><a href="https://akasha.ethereum.world/">Akasha</a> - A decentralized online bulletin board using <a href="https://www.wikipedia.org/wiki/InterPlanetary_File_System">IPFS</a> and <a href="https://www.wikipedia.org/wiki/Ethereum">Ethereum</a>.</li>
   <li><a href="https://dev.lemmy.ml/">Lemmy</a> - An <a href="https://github.com/dessalines/lemmy/blob/master/LICENSE">AGPL</a>-licensed self-hostable link aggregator intended to work in the <a href="https://www.wikipedia.org/wiki/Fediverse">Fediverse</a>.</li>
   <li><a href="https://notabug.io/">notabug.io</a> - A <a href="https://github.com/notabugio/notabug/blob/master/LICENSE.md">free and open-source</a> P2P link aggregator with a strong resemblance to old.reddit.com (not to be confused with <a href="https://notabug.org/">NotABug.org</a>).</li>
 </ul>


### PR DESCRIPTION
Correct the URL for Akasha on the social news aggregators page

## Description

Resolves: #2282

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [ X ] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [ X ] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [ X ] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: N/A - no visual changes

* Code repository of the project (if applicable): N/A
