### PR TITLE
Remove Kryptor beta label

### DIFF
--- a/_includes/sections/file-encryption.html
+++ b/_includes/sections/file-encryption.html
@@ -59,13 +59,5 @@
   <li><a href="https://gitlab.com/cryptsetup/cryptsetup/">Linux Unified Key Setup (LUKS)</a> - A full disk encryption system for Linux using dm-crypt as the disk encryption backend. Included by default in Ubuntu. Available for Windows and Linux.</li>
   <li><a href="https://www.dyne.org/software/tomb/">Tomb</a> - A simple zsh script for making LUKS containers on the commandline.</li>
   <li><a href="https://hat.sh/">Hat.sh</a> - A cross-platform, serverless JavaScript web application that provides secure file encryption using the AES-256-GCM algorithm in your browser. It can also be downloaded and run offline.</li>
-    <li>
-      <a href="https://www.kryptor.co.uk/">Kryptor</a> - Free and open source file encryption software for Windows, macOS, and Linux.
-      {% include badge.html
-        color="warning"
-        icon="fas fa-exclamation-triangle"
-        text="Beta"
-        tooltip="As Kryptor is still in beta, it may not be stable."
-      %}
-    </li>
+  <li><a href="https://www.kryptor.co.uk/">Kryptor</a> - Free and open source file encryption software for Windows, Linux, and macOS.</li>
 </ul>


### PR DESCRIPTION
## Description
Kryptor has now left beta as of [v3.0.3](https://github.com/samuel-lucas6/Kryptor/releases/tag/v3.0.3). I am the maintainer.

#### Check List <!-- Please add an x in each box below, like so: [x] -->

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

- [x] The project is [Free Libre](https://en.wikipedia.org/wiki/Free_software) and/or [Open Source](https://en.wikipedia.org/wiki/Open-source_software) Software

* Netlify preview for the mainly edited page: N/A

* Code repository of the project (if applicable): https://github.com/samuel-lucas6/Kryptor