### PR TITLE
Remove NixNet DNS and LibreDNS

### DIFF
--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -239,52 +239,7 @@ We also log how many times this or that tracker has been blocked. We need this i
           </span>
         </td>
       </tr>
-
-      <tr>
-        <td data-value="LibreDNS">
-          <a href="https://libredns.gr/">LibreDNS</a>
-        </td>
-        <td>
-          <span class="no-text-wrap">
-            <span class="flag-icon flag-icon-de"></span>
-            Germany
-          </span>
-        </td>
-        <td>
-          <a
-            class="btn-secondary btn-icon"
-            href="https://libreops.cc/terms.html">
-            <span class="fas fa-globe"></span>
-          </a>
-        </td>
-        <td>
-          <a data-toggle="tooltip" data-placement="bottom" data-original-title="Part of LibreHosters, &quot;a network of cooperation and solidarity that uses free software to encourage decentralisation through federation and distributed platforms.&quot;" href="https://libreho.st/">
-            Informal collective
-          </a>
-        </td>
-        <td>No</td>
-        <td>DoH, DoT</td>
-        <td>No</td>
-        <td>Yes</td>
-        <td>
-          <span class="no-text-wrap">
-            Based on server choice only for DoH
-          </span>
-        </td>
-        <td>
-          <a
-            class="btn-secondary btn-icon"
-            href="https://gitlab.com/libreops/libredns">
-            <span class="fas fa-globe"></span>
-          </a>
-        </td>
-        <td>
-          <span class="no-text-wrap">
-            <a href="https://www.hetzner.com/">Hetzner Online GmbH</a>
-          </span>
-        </td>
-      </tr>
-
+      
       <tr>
         <td data-value="nextdns">
           <a href="https://www.nextdns.io/">NextDNS</a>

--- a/_includes/sections/dns.html
+++ b/_includes/sections/dns.html
@@ -317,61 +317,7 @@ We also log how many times this or that tracker has been blocked. We need this i
         <td>?</td>
         <td>Self</td>
       </tr>
-
-      <tr>
-        <td data-value="NixNet">
-          <a href="https://nixnet.xyz/dns/">NixNet</a>
-        </td>
-        <td>
-          <span class="no-text-wrap">
-            Anycast (based in
-            <span class="flag-icon flag-icon-us"></span>
-            US),
-          </span>
-          <span class="no-text-wrap">
-            <span class="flag-icon flag-icon-us"></span>
-            US,
-          </span>
-          <span class="no-text-wrap">
-            <span class="flag-icon flag-icon-lu"></span>
-            Luxembourg
-          </span>
-        </td>
-        <td>
-          <a
-            class="btn-secondary btn-icon"
-            href="https://nixnet.xyz/privacy/">
-            <span class="fas fa-globe"></span>
-          </a>
-        </td>
-        <td>
-          <a data-toggle="tooltip" data-placement="bottom" data-original-title='Part of LibreHosters, "a network of cooperation and solidarity that uses free software to encourage decentralisation through federation and distributed platforms."' href="https://libreho.st/">
-            Informal collective
-          </a>
-        </td>
-        <td>No</td>
-        <td>DoH, DoT</td>
-        <td>Yes</td>
-        <td>Yes</td>
-        <td>
-          <span class="no-text-wrap">
-            Based on server choice
-          </span>
-        </td>
-        <td>
-          <a
-            class="btn-secondary btn-icon"
-            href="https://git.nixnet.xyz/NixNet/dns">
-            <span class="fas fa-globe"></span>
-          </a>
-        </td>
-        <td>
-          <span class="no-text-wrap">
-            <a href="https://frantech.ca/">FranTech Solutions</a>
-          </span>
-        </td>
-      </tr>
-
+      
       <tr>
         <td data-value="PowerDNS">
           <a href="https://powerdns.org/">PowerDNS</a>


### PR DESCRIPTION
## Description

Removal of NixNet DNS because they are [shutting down](https://docs.nixnet.services/NixNet_DNS) their DNS service.
Removal of LibreDNS because they do not support DNSSEC.

Resolves:  #2404
Resolves:  #2157
Resolves: #2216 
Resolves: #2411 

#### Check List

- [x] I understand that by not opening an issue about a software/service/similar addition/removal, this pull request will be closed without merging.

- [x] I have read and understand [the contributing guidelines](https://github.com/privacytools/privacytools.io/blob/master/.github/CONTRIBUTING.md).

* Netlify preview for the mainly edited page: 

